### PR TITLE
Very small fix changing http to https

### DIFF
--- a/pygist.py
+++ b/pygist.py
@@ -44,7 +44,7 @@ import urllib2
 
 from urllib import urlencode
 
-site = 'http://gist.github.com/gists'
+site = 'https://gist.github.com/gists'
 
 def get_command_output(argv):
     sp = subprocess.Popen(argv,


### PR DESCRIPTION
Hi,

Started using pygist today, but appeared to be broken, turns out github now 302 redirects the gist site to https.

Anyway here is a simple fix for the issue.

Thanks,

Peter
